### PR TITLE
[PARSING] added level order left handed precedence for ops in eval.

### DIFF
--- a/js/logic.js
+++ b/js/logic.js
@@ -2,14 +2,12 @@ function evalutate (equation, values) {
    var eq = equation;
    Object.keys(values).forEach(v => {
       eq = eq.replace(new RegExp(v, "g"), values[v]);
-   })
-
-   eq = convertOPStoJS(eq)
-
+   });
    return new Number(eval(eq))
 }
 
 function convertOPStoJS (opStr) {
+   opStr = sameLevelOps(opStr);
    return opStr.replace(ALL_AND, "&&")
                .replace(ALL_NAND, "!==1||1!==")
                .replace(ALL_OR,  "||")
@@ -18,4 +16,28 @@ function convertOPStoJS (opStr) {
                .replace(ALL_NOT, "!")
                .replace(ALL_IMP, "==0?1:")
                .replace(ALL_IFF, "==");
+}
+
+function sameLevelOps (opStr) {
+   var str = "", levelOps = 0, p = 0, inside = "";
+   for (var i = 0; i < opStr.length; i++) {
+      if (opStr[i] === "(") {
+         p++;
+      } else if (opStr[i] === ")") {
+         p--;
+         if (p === 0) {
+            str += "(" + sameLevelOps(inside.substr(1));
+         }
+      } else if (p < 1 && opStr[i] !== NOT && OPS.test(opStr[i])) {
+         levelOps++;
+         str += ")";
+      }
+      if (p > 0) {
+         inside += opStr[i];
+      } else {
+         str += opStr[i];
+      }
+   }
+   str = "(".repeat(levelOps) + str;
+   return str;
 }


### PR DESCRIPTION
I added a pre-parsing algorithm that takes operators of same level order and gives them a left handed precedence. `p ∨ ¬q ∧ r` now becomes `((p) ∨ ¬ q) ∧ r`. Which is "less efficient" but more accurate. To quote Ron Jones, "A working inefficient algorithm is better than a broken optimized one."

---
Concerning Item #17
